### PR TITLE
feat: implement Playwright CDP adapter for issue #2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,31 @@
+{
+  "name": "screenshot-autmation-runner",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "screenshot-autmation-runner",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "playwright-core": "^1.58.2"
+      },
+      "bin": {
+        "sar": "bin/sar.js"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -20,5 +20,8 @@
   ],
   "author": "sugi-cho",
   "license": "ISC",
-  "type": "module"
+  "type": "module",
+  "dependencies": {
+    "playwright-core": "^1.58.2"
+  }
 }

--- a/test/e2e/minimal.e2e.test.ts
+++ b/test/e2e/minimal.e2e.test.ts
@@ -2,8 +2,10 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import path from "node:path";
 import { main } from "../../src/cli/index.js";
+import { ExitCode } from "../../src/logging/error-codes.js";
 
 const configPath = path.resolve("test", "fixtures", "minimal.config.json");
+const cdpFailConfigPath = path.resolve("test", "fixtures", "cdp-fail.config.json");
 
 test("cli validate succeeds", () => {
   return main(["validate", "-c", configPath]).then((code) => {
@@ -14,5 +16,11 @@ test("cli validate succeeds", () => {
 test("cli run dry-run succeeds", () => {
   return main(["run", "-c", configPath, "--dry-run"]).then((code) => {
     assert.equal(code, 0);
+  });
+});
+
+test("cli run returns 21 when cdp connect fails", () => {
+  return main(["run", "-c", cdpFailConfigPath]).then((code) => {
+    assert.equal(code, ExitCode.CDP_CONNECT_FAILED);
   });
 });

--- a/test/fixtures/cdp-fail.config.json
+++ b/test/fixtures/cdp-fail.config.json
@@ -1,0 +1,35 @@
+{
+  "version": 1,
+  "project": "fixture-project-cdp-fail",
+  "launch": {
+    "type": "command",
+    "command": "node -e \"setTimeout(() => {}, 30000)\""
+  },
+  "automation": {
+    "adapter": "playwright-cdp",
+    "cdpPort": 59999,
+    "connectTimeoutMs": 200,
+    "viewport": {
+      "width": 800,
+      "height": 600
+    }
+  },
+  "output": {
+    "dir": "test-output/screenshots",
+    "fileNameTemplate": "{index:02}-{name}.png",
+    "overwrite": true
+  },
+  "scenario": {
+    "name": "cdp-fail",
+    "steps": [
+      {
+        "id": "st-01",
+        "type": "wait",
+        "until": {
+          "kind": "timeout",
+          "ms": 10
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- implement playwright-cdp adapter with real connectOverCDP flow
- add viewport setup and adapter operations (wait/click/input/key/screenshot/content/evaluateCondition/close)
- add e2e case that asserts non-dry-run returns exit code 21 when CDP connect fails
- add playwright-core dependency and lockfile

## Verification
- npm run build
- npm test
- npm run e2e:min

Closes #2